### PR TITLE
Edit manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ osx_image: xcode9
 language: objective-c
 
 script:
-- swift test
+  - swift build
+# - swift test
 
 notifications:
   email:

--- a/Package.resolved
+++ b/Package.resolved
@@ -47,6 +47,15 @@
         }
       },
       {
+        "package": "Regex",
+        "repositoryURL": "https://github.com/sharplet/Regex",
+        "state": {
+          "branch": null,
+          "revision": "3e671ed911b467c0d9c05e56f03d9e5bcb535f39",
+          "version": "1.1.0"
+        }
+      },
+      {
         "package": "ShellOut",
         "repositoryURL": "https://github.com/JohnSundell/ShellOut",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -15,13 +15,14 @@ let package = Package(
         .package(url: "https://github.com/JohnSundell/ShellOut", from: "1.1.0"),
         .package(url: "https://github.com/kiliankoe/CLISpinner", from: "0.3.3"),
         .package(url: "https://github.com/IBM-Swift/BlueSignals", from: "0.9.48"),
+        .package(url: "https://github.com/sharplet/Regex", from: "1.1.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "ApodidaeCore",
-            dependencies: ["PromiseKit", "Files", "Rainbow"]),
+            dependencies: ["PromiseKit", "Files", "Rainbow", "Regex"]),
         .target(
             name: "swift-catalog",
             dependencies: ["ApodidaeCore", "CommandLine", "ShellOut", "CLISpinner", "Signals"]),

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The following has been copied to your clipboard for convenience, just paste it i
 .package(url: "https://github.com/ReactiveX/RxSwift", from: "3.6.1"),
 ```
 
-Apodidae will try to figure out if the project in the current directory uses Swift 3 or 4 and output accordingly. You can also override manually using the `--swiftversion n` flag.
+Apodidae will try to figure out if the project in the current directory uses Swift 3 or 4 and output accordingly.
 
 It's also possible to add a specific version or other requirement. All you have to do is add `@requirement` to the end of the package. This syntax may feel familiar if you've used npm. The following all work.
 

--- a/README.md
+++ b/README.md
@@ -64,11 +64,11 @@ You can also run `swift catalog home rxswift` to directly open the homepage to a
 
 ```
 $ swift catalog add rxswift
-The following has been copied to your clipboard for convenience, just paste it into your package manifests's dependencies.
-.package(url: "https://github.com/ReactiveX/RxSwift", from: "3.6.1"),
+Added ReactiveX/RxSwift to your package manifest.
+✔ Successfully resolved dependencies.
 ```
 
-Apodidae will try to figure out if the project in the current directory uses Swift 3 or 4 and output accordingly.
+Apodidae will try to figure out if the project in the current directory uses Swift 3 or 4 and edit your manifest accordingly. After adding it to your manifest apodidae calls out to `swift package resolve` to resolve your new list of dependencies. If unwanted this can be skipped using the flag `--no-resolve`. 
 
 It's also possible to add a specific version or other requirement. All you have to do is add `@requirement` to the end of the package. This syntax may feel familiar if you've used npm. The following all work.
 

--- a/Sources/ApodidaeCore/Git.swift
+++ b/Sources/ApodidaeCore/Git.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Files
+import ShellOut
+
+public enum Git {
+    public enum Error: Swift.Error {
+        case notARepo
+    }
+
+    public static func uncommitedChanges(in dir: Folder = Folder.current) throws -> Bool {
+        let result = try shellOut(to: "git", arguments: ["status -s"], at: dir.path)
+        guard !result.contains("Not a git repository") else { throw Error.notARepo }
+        return !result.isEmpty
+    }
+}
+
+extension Git.Error: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .notARepo: return "Not a git repository (or any of the parent directories)"
+        }
+    }
+}

--- a/Sources/ApodidaeCore/Manifest.swift
+++ b/Sources/ApodidaeCore/Manifest.swift
@@ -11,7 +11,7 @@ public enum Manifest {
     public static func findDependenciesInsertLocation(in manifest: String) throws -> (line: Int, indentation: Int) {
         let previousPackagesRegex = Regex("url: \"(\\S+)\",(.+)\\)")
         let dependenciesRegex = Regex("dependencies:\\s?\\[")
-        let targetsRegex = Regex("targets")
+        let targetsRegex = Regex("target\\(", options: .ignoreCase)
 
         let previousPackages = previousPackagesRegex.allMatches(in: manifest)
         if previousPackages.count > 0 {

--- a/Sources/ApodidaeCore/Manifest.swift
+++ b/Sources/ApodidaeCore/Manifest.swift
@@ -53,6 +53,12 @@ public enum Manifest {
         manifestLines.insert("\(indentationPrefix)\(packageString)", at: line)
         return manifestLines.joined(separator: "\n")
     }
+
+    public static func insertIntoLocalManifest(package: Repository, requirement: Requirement) throws {
+        let localManifest = try Folder.current.file(named: "Package.swift").readAsString()
+        let newManifest = try Manifest.insert(package: package, requirement: requirement, into: localManifest)
+        try Folder.current.file(atPath: "Package.swift").write(string: newManifest)
+    }
 }
 
 extension Regex {

--- a/Sources/ApodidaeCore/Manifest.swift
+++ b/Sources/ApodidaeCore/Manifest.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Files
+import Regex
+
+public enum Manifest {
+
+    public enum Error: Swift.Error {
+        case unsupportedLayout(reason: String)
+    }
+
+    public static func findDependenciesInsertLocation(in manifest: String) throws -> (line: Int, indentation: Int) {
+        let previousPackagesRegex = Regex("url: \"(\\S+)\",(.+)\\)")
+        let dependenciesRegex = Regex("dependencies:\\s?\\[")
+        let targetsRegex = Regex("targets")
+
+        let previousPackages = previousPackagesRegex.allMatches(in: manifest)
+        if previousPackages.count > 0 {
+            guard let lastPackageLocation = previousPackagesRegex.lineNumbersOfMatches(in: manifest).last else {
+                throw Error.unsupportedLayout(reason: "Found packages, but no packages. Wat. This shouldn't be happening o.O")
+            }
+            // FIXME: Indentation shouldn't be hardcoded
+            // FIXME: Handle possibly missing trailing commas
+            return (lastPackageLocation + 1, 8)
+        } else {
+            // List of dependencies is either empty or non-existant
+
+            let targetsCount = targetsRegex.allMatches(in: manifest).count
+            let dependenciesCount = dependenciesRegex.allMatches(in: manifest).count
+            guard dependenciesCount > targetsCount else {
+                // FIXME: This should obviously be improved...
+                throw Error.unsupportedLayout(reason: "Found \(targetsCount) targets with \(dependenciesCount) dependencies. Can't safely distinguish.\nThis is considered a bug in apodidae. Please open an issue with your Package.swift, thanks!")
+            }
+
+            guard let dependenciesListLocation = dependenciesRegex.lineNumbersOfMatches(in: manifest).first else {
+                throw Error.unsupportedLayout(reason: "Found no list of dependencies. Please make sure your Package.swift includes at least an empty list of dependencies.")
+            }
+
+            // FIXME: Indentation shouldn't be hardcoded
+            // FIXME: What if it's "dependencies: []" with the closing bracket on the same line? Handle that.
+            return (dependenciesListLocation + 1, 8)
+        }
+    }
+
+    public static func insert(package: Repository, requirement: Requirement, into manifest: String) throws -> String {
+        let swiftVersion = SwiftVersion.guessVersion(fromPackageContents: manifest)
+        let (line, indentation) = try findDependenciesInsertLocation(in: manifest)
+
+        var manifestLines = manifest
+            .split(separator: "\n", omittingEmptySubsequences: false) // preserve whitespace
+            .map(String.init)
+        let packageString = try package.dependencyRepresentation(for: swiftVersion, requirement: requirement)
+        let indentationPrefix = Array(repeating: " ", count: indentation).joined()
+        manifestLines.insert("\(indentationPrefix)\(packageString)", at: line)
+        return manifestLines.joined(separator: "\n")
+    }
+}
+
+extension Regex {
+    func lineNumbersOfMatches(in file: String) -> [Int] {
+        return file
+            .split(separator: "\n", omittingEmptySubsequences: false) // preserve whitespace
+            .enumerated()
+            .flatMap { arg -> Int? in
+                let (offset, element) = arg
+                if self.matches(String(element)) {
+                    return offset
+                }
+                return nil
+            }
+    }
+}
+
+extension Manifest.Error: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedLayout(let reason): return "The layout of your Package.swift is unsupported. \(reason)"
+        }
+    }
+}

--- a/Sources/ApodidaeCore/Manifest.swift
+++ b/Sources/ApodidaeCore/Manifest.swift
@@ -16,7 +16,7 @@ public enum Manifest {
         let previousPackages = previousPackagesRegex.allMatches(in: manifest)
         if previousPackages.count > 0 {
             guard let lastPackageLocation = previousPackagesRegex.lineNumbersOfMatches(in: manifest).last else {
-                throw Error.unsupportedLayout(reason: "Found packages, but no packages. Wat. This shouldn't be happening o.O")
+                throw Error.unsupportedLayout(reason: "Found packages, but no packages. Wat. This shouldn't be happening o.O\nThis is considered a bug in apodidae. Please open an issue with your Package.swift, thanks!")
             }
             // FIXME: Indentation shouldn't be hardcoded
             // FIXME: Handle possibly missing trailing commas

--- a/Sources/ApodidaeCore/Manifest.swift
+++ b/Sources/ApodidaeCore/Manifest.swift
@@ -6,6 +6,7 @@ public enum Manifest {
 
     public enum Error: Swift.Error {
         case unsupportedLayout(reason: String)
+        case packageAlreadyExists
     }
 
     public static func findDependenciesInsertLocation(in manifest: String) throws -> (line: Int, indentation: Int) {
@@ -42,6 +43,8 @@ public enum Manifest {
     }
 
     public static func insert(package: Repository, requirement: Requirement, into manifest: String) throws -> String {
+        guard !manifest.contains(package.nameWithOwner) else { throw Error.packageAlreadyExists }
+
         let swiftVersion = SwiftVersion.guessVersion(fromPackageContents: manifest)
         let (line, indentation) = try findDependenciesInsertLocation(in: manifest)
 
@@ -80,6 +83,7 @@ extension Manifest.Error: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .unsupportedLayout(let reason): return "The layout of your Package.swift is unsupported. \(reason)"
+        case .packageAlreadyExists: return "The package to add already exists in your package manifest."
         }
     }
 }

--- a/Sources/ApodidaeCore/SwiftVersion.swift
+++ b/Sources/ApodidaeCore/SwiftVersion.swift
@@ -14,13 +14,20 @@ public enum SwiftVersion {
 
     public static var currentStable: SwiftVersion = .v3
 
-    public static func readFromLocalPackage() -> SwiftVersion {
-        guard let packageManifest = try? Folder.current.file(named: "Package.swift").readAsString() else {
-            return currentStable
-        }
-        if packageManifest.contains("swift-tools-version:3") {
+    public static func readFromLocalPackage() throws -> SwiftVersion {
+        return try readFrom(packageManifest: Folder.current.file(named: "Package.swift"))
+    }
+
+    public static func readFrom(packageManifest: File) throws -> SwiftVersion {
+        let manifest = try packageManifest.readAsString()
+        return guessVersion(fromPackageContents: manifest)
+    }
+
+    public static func guessVersion(fromPackageContents manifest: String) -> SwiftVersion {
+        if manifest.contains("swift-tools-version:3") || manifest.contains(".Package") {
             return .v3
-        } else if packageManifest.contains("swift-tools-version:4") {
+        } else if manifest.contains("swift-tools-version:4") || manifest.contains(".package") {
+            // Checking for `.package` for v4 will fail on future swift versions. It should just be here temporarily...
             return .v4
         } else {
             return currentStable

--- a/Sources/swift-catalog/Confirm.swift
+++ b/Sources/swift-catalog/Confirm.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+func confirm(_ text: String, default: Bool) -> Bool {
+    let suffix = `default` ? "[Yn]" : "[yN]"
+
+    while true {
+        print("\(text) \(suffix)")
+        guard let input = readLine(strippingNewline: true) else { continue }
+        switch input.lowercased() {
+        case "": return `default`
+        case "y", "yes": return true
+        case "n", "no": return false
+        default:
+            print("Invalid input, expected 'y', 'yes', 'n' or 'no'.")
+        }
+    }
+}

--- a/Sources/swift-catalog/Confirm.swift
+++ b/Sources/swift-catalog/Confirm.swift
@@ -5,7 +5,7 @@ func confirm(_ text: String, default: Bool) -> Bool {
 
     while true {
         print("\(text) \(suffix)")
-        guard let input = readLine(strippingNewline: true) else { continue }
+        guard let input = readLine() else { continue }
         switch input.lowercased() {
         case "": return `default`
         case "y", "yes": return true

--- a/Sources/swift-catalog/main.swift
+++ b/Sources/swift-catalog/main.swift
@@ -168,7 +168,7 @@ case .add(let input):
             try Manifest.insertIntoLocalManifest(package: repo, requirement: requirement)
             print("Added \(repo.nameWithOwner.lightCyan) to your package manifest.")
         } catch {
-            print("An error occurred editing your package manifest: \(error.localizedDescription)")
+            print("An error occurred editing your package manifest: \(error.localizedDescription.red)")
             let swiftVersion = try SwiftVersion.readFromLocalPackage()
             let packageString = try repo.dependencyRepresentation(for: swiftVersion, requirement: requirement)
             try shellOut(to: "echo '\(packageString)' | pbcopy")

--- a/Sources/swift-catalog/main.swift
+++ b/Sources/swift-catalog/main.swift
@@ -26,9 +26,7 @@ let version = BoolOption(longFlag: "version", helpMessage: "Output the version o
 let verbosity = BoolOption(shortFlag: "v", longFlag: "verbose", helpMessage: "Print verbose messages.")
 
 let searchForksFlag = BoolOption(shortFlag: "f", longFlag: "search-forks", helpMessage: "Search for forks matching the query as well.")
-let swiftVersionFlag = IntOption(longFlag: "swiftversion", helpMessage: "Manually specify a swift version for the generated dependency string on `swift catalog add`.")
 
-cli.addOptions(help, version, verbosity, searchForksFlag, swiftVersionFlag)
 
 do {
     try cli.parse()

--- a/Sources/swift-catalog/main.swift
+++ b/Sources/swift-catalog/main.swift
@@ -136,6 +136,14 @@ case .add(let input):
 
         if verbosity.wasSet { print(meta.cliRepresentation) }
 
+        if try Git.uncommitedChanges() {
+            print("There are uncommitted changes present in your working directory.")
+            guard confirm("Do you want to continue anyways?", default: true) else {
+                print("Exiting without changes.")
+                exit(0)
+            }
+        }
+
         let swiftVersion: SwiftVersion
         if swiftVersionFlag.wasSet, let version = SwiftVersion(from: swiftVersionFlag.value ?? 0) {
             swiftVersion = version

--- a/Sources/swift-catalog/main.swift
+++ b/Sources/swift-catalog/main.swift
@@ -140,7 +140,7 @@ case .add(let input):
         if swiftVersionFlag.wasSet, let version = SwiftVersion(from: swiftVersionFlag.value ?? 0) {
             swiftVersion = version
         } else {
-            swiftVersion = SwiftVersion.readFromLocalPackage()
+            swiftVersion = try SwiftVersion.readFromLocalPackage()
         }
 
         let packageString: String

--- a/Sources/swift-catalog/main.swift
+++ b/Sources/swift-catalog/main.swift
@@ -164,7 +164,7 @@ case .add(let input):
 
         do {
             try Manifest.insertIntoLocalManifest(package: repo, requirement: requirement)
-            print("Added \(input.package) to your package manifest.".lightCyan)
+            print("Added \(repo.nameWithOwner.lightCyan) to your package manifest.")
         } catch {
             print("An error occurred editing your package manifest: \(error.localizedDescription)")
             let swiftVersion = try SwiftVersion.readFromLocalPackage()

--- a/Tests/ApodidaeTests/ManifestTests.swift
+++ b/Tests/ApodidaeTests/ManifestTests.swift
@@ -106,6 +106,31 @@ class ManifestTests: XCTestCase {
         XCTAssertEqual(newManifest, expected)
     }
 
+    func testInsertPackageIntoManifestWitSingleLineDependencies() {
+        let package = Repository(name: "kiliankoe/apodidae", url: "https://github.com/kiliankoe/apodidae")
+        let manifestWithSingleLineDependencies = """
+        import PackageDescription
+
+        let package = Package(
+            name: "manifest",
+            dependencies: []
+        )
+        """
+        let newManifest = try! Manifest.insert(package: package, requirement: .tag(package.latestVersion!), into: manifestWithSingleLineDependencies)
+
+        let expected = """
+        import PackageDescription
+
+        let package = Package(
+            name: "manifest",
+            dependencies: [
+                .Package(url: "https://github.com/kiliankoe/apodidae", majorVersion: 0, minor: 1),
+            ]
+        )
+        """
+        XCTAssertEqual(newManifest, expected)
+    }
+
     func testInsertPackageIntoManifestWithPackages() {
         let package = Repository(name: "kiliankoe/apodidae", url: "https://github.com/kiliankoe/apodidae")
         let manifestWithPackages = """

--- a/Tests/ApodidaeTests/ManifestTests.swift
+++ b/Tests/ApodidaeTests/ManifestTests.swift
@@ -1,0 +1,162 @@
+import XCTest
+@testable import ApodidaeCore
+import Regex
+
+class ManifestTests: XCTestCase {
+    func testLineNumberOfMatches() {
+        let barRegex = Regex("bar")
+
+        let str1 = """
+        foo
+        bar
+        baz
+        """
+        let barLines1 = barRegex.lineNumbersOfMatches(in: str1)
+        XCTAssertEqual(barLines1, [1])
+
+        let str2 = """
+        bar
+        foo
+        bar
+        """
+        let barLines2 = barRegex.lineNumbersOfMatches(in: str2)
+        XCTAssertEqual(barLines2, [0, 2])
+
+        let str3 = """
+        foo
+        baz
+        """
+        let barLines3 = barRegex.lineNumbersOfMatches(in: str3)
+        XCTAssertEqual(barLines3, [])
+    }
+
+    func testFindDependenciesInsert() {
+        let manifestWithoutPackages = """
+        import PackageDescription
+
+        let package = Package(
+            name: "manifest",
+            dependencies: [
+            ]
+        )
+        """
+
+        let (line1, indentation1) = try! Manifest.findDependenciesInsertLocation(in: manifestWithoutPackages)
+        XCTAssertEqual(line1, 5)
+        XCTAssertEqual(indentation1, 8)
+
+        let manifestWithPackages = """
+        import PackageDescription
+
+        let package = Package(
+            name: "manifest",
+            dependencies: [
+                .package(url: "foo", from: ""),
+                .package(url: "bar", from: ""),
+                .package(url: "baz", from: ""),
+            ]
+        )
+        """
+
+        let (line2, indentation2) = try! Manifest.findDependenciesInsertLocation(in: manifestWithPackages)
+        XCTAssertEqual(line2, 8)
+        XCTAssertEqual(indentation2, 8)
+    }
+
+    func testFailingDependenciesInsert() {
+        let manifestWithoutDependencies = """
+        import PackageDescription
+
+        let package = Package(
+            name: "manifest"
+        )
+        """
+
+        do {
+            let _ = try Manifest.findDependenciesInsertLocation(in: manifestWithoutDependencies)
+            XCTFail("Shouldn't find insert points in manifest without a list of dependencies.")
+        } catch {
+            XCTAssert(error is Manifest.Error)
+        }
+    }
+
+    func testInsertPackageIntoManifestWithoutPackages() {
+        let package = Repository(name: "kiliankoe/apodidae", url: "https://github.com/kiliankoe/apodidae")
+        let manifestWithoutPackages = """
+        import PackageDescription
+
+        let package = Package(
+            name: "manifest",
+            dependencies: [
+            ]
+        )
+        """
+        let newManifest = try! Manifest.insert(package: package, requirement: .tag(package.latestVersion!), into: manifestWithoutPackages)
+
+        let expected = """
+        import PackageDescription
+
+        let package = Package(
+            name: "manifest",
+            dependencies: [
+                .Package(url: "https://github.com/kiliankoe/apodidae", majorVersion: 0, minor: 1),
+            ]
+        )
+        """
+        XCTAssertEqual(newManifest, expected)
+    }
+
+    func testInsertPackageIntoManifestWithPackages() {
+        let package = Repository(name: "kiliankoe/apodidae", url: "https://github.com/kiliankoe/apodidae")
+        let manifestWithPackages = """
+        import PackageDescription
+
+        let package = Package(
+            name: "manifest",
+            dependencies: [
+                .package(url: "foo", from: ""),
+                .package(url: "bar", from: ""),
+            ]
+        )
+        """
+        let newManifest = try! Manifest.insert(package: package, requirement: .tag(package.latestVersion!), into: manifestWithPackages)
+
+        let expected = """
+        import PackageDescription
+
+        let package = Package(
+            name: "manifest",
+            dependencies: [
+                .package(url: "foo", from: ""),
+                .package(url: "bar", from: ""),
+                .package(url: "https://github.com/kiliankoe/apodidae", from: "0.1.0"),
+            ]
+        )
+        """
+        XCTAssertEqual(newManifest, expected)
+    }
+}
+
+extension Repository {
+    init(name: String, url: String) {
+        self.nameWithOwner = name
+        self.url = URL(string: url)!
+
+        self.description = ""
+        self.isFork = false
+        self.parent = nil
+        self.isPrivate = false
+        self.pushedAt = Date.distantPast
+        self.license = nil
+        self.openIssues = 0
+        self.stargazers = 0
+        self.tags = [Repository.Tag(name: "0.1.0")]
+        self.hasPackageManifest = true
+    }
+}
+
+extension Repository.Tag {
+    init(name: String) {
+        self.name = name
+    }
+}


### PR DESCRIPTION
See #11

- [x] Check for uncommitted changes before editing Package.swift
- [x] Actually run from main.swift
- [x] Run `swift package resolve`
- [x] Add `--no-resolve` flag
- [x] Support Package.swift with `dependiences: []` in one line
- [x] Fail if a package to add already exists
- [x] edit README
- [ ] ~fix hardcoded indentation~ ok for now