### PR TITLE
Improve version handling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "ApodidaeCore",
-            dependencies: ["PromiseKit", "Files", "Rainbow", "Regex"]),
+            dependencies: ["PromiseKit", "Files", "Rainbow", "Regex", "CLISpinner"]),
         .target(
             name: "swift-catalog",
             dependencies: ["ApodidaeCore", "CommandLine", "ShellOut", "CLISpinner", "Signals"]),

--- a/Sources/ApodidaeCore/Git.swift
+++ b/Sources/ApodidaeCore/Git.swift
@@ -19,7 +19,7 @@ public enum Git {
         guard !result.contains("remote: Not Found") else { throw Error.remoteNotFound }
         let refs = result
             .split(separator: "\n")
-            .map { $0.split(separator: " ") }
+            .map { $0.split(separator: "\t") }
             .flatMap { $0.last }
             .map(String.init)
 

--- a/Sources/ApodidaeCore/Git.swift
+++ b/Sources/ApodidaeCore/Git.swift
@@ -37,6 +37,14 @@ public enum Git {
                 }
                 return tag
             }
+            .map { tag -> String in
+                // some people leave of the patch version, which spm/semver requires.
+                // FIXME: This is very naive and doesn't handle things like `2.0-alpha.1` correctly.
+                if tag.split(separator: ".").count < 3 {
+                    return "\(tag).0"
+                }
+                return tag
+            }
 
         let sortedDeduplicatedTags = Array(Set(tags)).sorted(by: >)
 

--- a/Sources/ApodidaeCore/Git.swift
+++ b/Sources/ApodidaeCore/Git.swift
@@ -5,6 +5,7 @@ import ShellOut
 public enum Git {
     public enum Error: Swift.Error {
         case notARepo
+        case remoteNotFound
     }
 
     public static func uncommitedChanges(in dir: Folder = Folder.current) throws -> Bool {
@@ -12,12 +13,33 @@ public enum Git {
         guard !result.contains("Not a git repository") else { throw Error.notARepo }
         return !result.isEmpty
     }
+
+    public static func ls(remote: String) throws -> (heads: [String], tags: [String]) {
+        let result = try shellOut(to: "git", arguments: ["ls-remote", "--heads", "--tags", remote])
+        guard !result.contains("remote: Not Found") else { throw Error.remoteNotFound }
+        let refs = result
+            .split(separator: "\n")
+            .map { $0.split(separator: " ") }
+            .flatMap { $0.last }
+            .map(String.init)
+
+        let heads = refs
+            .filter { $0.hasPrefix("refs/heads") }
+            .map { $0.replacingOccurrences(of: "refs/heads/", with: "") }
+
+        let tags = refs
+            .filter { $0.hasPrefix("refs/tags") }
+            .map { $0.replacingOccurrences(of: "refs/tags/", with: "") }
+
+        return (heads, tags)
+    }
 }
 
 extension Git.Error: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .notARepo: return "Not a git repository (or any of the parent directories)"
+        case .remoteNotFound: return "Remote not found"
         }
     }
 }

--- a/Sources/ApodidaeCore/Git.swift
+++ b/Sources/ApodidaeCore/Git.swift
@@ -29,10 +29,18 @@ public enum Git {
 
         let tags = refs
             .filter { $0.hasPrefix("refs/tags") }
-            .filter { !$0.contains("^{") } // filter github releases (I think these are releases)
             .map { $0.replacingOccurrences(of: "refs/tags/", with: "") }
+            .filter { !$0.contains("^{") } // filter github releases (I think these are releases)
+            .map { tag -> String in
+                if tag.lowercased().hasPrefix("v") {
+                    return String(tag.dropFirst())
+                }
+                return tag
+            }
 
-        return (heads, tags)
+        let sortedDeduplicatedTags = Array(Set(tags)).sorted(by: >)
+
+        return (heads, sortedDeduplicatedTags)
     }
 }
 

--- a/Sources/ApodidaeCore/Git.swift
+++ b/Sources/ApodidaeCore/Git.swift
@@ -29,6 +29,7 @@ public enum Git {
 
         let tags = refs
             .filter { $0.hasPrefix("refs/tags") }
+            .filter { !$0.contains("^{") } // filter github releases (I think these are releases)
             .map { $0.replacingOccurrences(of: "refs/tags/", with: "") }
 
         return (heads, tags)

--- a/Sources/ApodidaeCore/GitHub.swift
+++ b/Sources/ApodidaeCore/GitHub.swift
@@ -34,13 +34,6 @@ struct RepoQuery: GraphQLQuery {
               stargazers(first: 0) {
                 totalCount
               }
-              tags: refs(refPrefix: "refs/tags/", last: 5) {
-                edges {
-                  node {
-                    name
-                  }
-                }
-              }
               packageManifest: object(expression: "master:Package.swift") {
                 ... on Blob {
                   abbreviatedOid

--- a/Sources/ApodidaeCore/Repository.swift
+++ b/Sources/ApodidaeCore/Repository.swift
@@ -111,9 +111,8 @@ public struct Repository: Decodable {
     }
 
     public var longCliRepresentation: String {
-        let versions = self.tags
-            .map { $0.name }
-            .reversed()
+        let bound = self.tags.count >= 8 ? 8 : self.tags.count
+        let versions = self.tags[..<bound]
             .joined(separator: ", ")
         let priv = isPrivate ? "private" : ""
         let fork = "Fork of \(parent ?? "unknown")".lightBlue

--- a/Sources/ApodidaeCore/Repository.swift
+++ b/Sources/ApodidaeCore/Repository.swift
@@ -91,7 +91,7 @@ public struct Repository: Decodable {
     }
 
     public var latestVersion: String? {
-        return tags.last
+        return tags.first
     }
 
     public var shortCliRepresentation: String {

--- a/Sources/ApodidaeCore/Repository.swift
+++ b/Sources/ApodidaeCore/Repository.swift
@@ -12,7 +12,7 @@ public struct Repository: Decodable {
     public let license: String?
     public let openIssues: Int
     public let stargazers: Int
-    public let tags: [Tag]
+    public var tags: [Tag]
     public let hasPackageManifest: Bool
 
     public var owner: String {

--- a/Sources/ApodidaeCore/Repository.swift
+++ b/Sources/ApodidaeCore/Repository.swift
@@ -175,7 +175,16 @@ public struct Repository: Decodable {
         public init(from decoder: Decoder) throws {
             let nodeContainer = try decoder.container(keyedBy: NodeKeys.self)
             let container = try nodeContainer.nestedContainer(keyedBy: CodingKeys.self, forKey: .node)
-            self.name = try container.decode(String.self, forKey: .name)
+            let name = try container.decode(String.self, forKey: .name)
+            self.init(with: name)
+        }
+
+        public init(with name: String) {
+            if name.hasPrefix("v") {
+                self.name = String(name.dropFirst())
+            } else {
+                self.name = name
+            }
         }
     }
 }

--- a/Sources/ApodidaeCore/Repository.swift
+++ b/Sources/ApodidaeCore/Repository.swift
@@ -138,6 +138,7 @@ public struct Repository: Decodable {
 
         Last activity: \(pushedAt.iso)
         Last versions: \(versions)
+        Branches: \(heads.joined(separator: ", "))
         """
 
         return output

--- a/Sources/swift-catalog/main.swift
+++ b/Sources/swift-catalog/main.swift
@@ -102,7 +102,7 @@ case .search(let query):
         exit(1)
     }
 case .info(let input):
-    GitHub.firstRepo(with: input, accessToken: config.githubAccessToken, searchForks: searchForksFlag.wasSet).then { response in
+    GitHub.firstRepoIncludingRefs(with: input, accessToken: config.githubAccessToken, searchForks: searchForksFlag.wasSet, spinner: spinner).then { response in
         let (repo, meta) = response
 
         spinner.stopAndClear()
@@ -157,7 +157,7 @@ case .add(let input):
         if let req = input.requirement {
             requirement = req
         } else {
-            if let latestVersion = repo.tags.last?.name {
+            if let latestVersion = repo.tags.last {
                 requirement = .tag(latestVersion)
             } else {
                 requirement = .branch("master")

--- a/Sources/swift-catalog/main.swift
+++ b/Sources/swift-catalog/main.swift
@@ -157,7 +157,7 @@ case .add(let input):
         if let req = input.requirement {
             requirement = req
         } else {
-            if let latestVersion = repo.tags.last {
+            if let latestVersion = repo.latestVersion {
                 requirement = .tag(latestVersion)
             } else {
                 requirement = .branch("master")

--- a/Sources/swift-catalog/main.swift
+++ b/Sources/swift-catalog/main.swift
@@ -160,7 +160,7 @@ case .add(let input):
             if let latestVersion = repo.latestVersion {
                 requirement = .tag(latestVersion)
             } else {
-                requirement = .branch("master")
+                requirement = repo.heads.contains("master") ? .branch("master") : .branch(repo.heads.first!) // this will crash if the repo contains no branches... Can that happen?
             }
         }
 

--- a/Sources/swift-catalog/main.swift
+++ b/Sources/swift-catalog/main.swift
@@ -130,7 +130,7 @@ case .home(let input):
         exit(1)
     }
 case .add(let input):
-    GitHub.firstRepo(with: input.package, accessToken: config.githubAccessToken, searchForks: searchForksFlag.wasSet).then { response in
+    GitHub.firstRepoIncludingRefs(with: input.package, accessToken: config.githubAccessToken, searchForks: searchForksFlag.wasSet, spinner: spinner).then { response in
         let (repo, meta) = response
 
         spinner.stopAndClear()

--- a/Tests/ApodidaeTests/GitHubTests.swift
+++ b/Tests/ApodidaeTests/GitHubTests.swift
@@ -25,35 +25,6 @@ class GitHubTests: XCTestCase {
                     "stargazers": {
                       "totalCount": 11
                     },
-                    "tags": {
-                      "edges": [
-                        {
-                          "node": {
-                            "name": "1.1.0"
-                          }
-                        },
-                        {
-                          "node": {
-                            "name": "2.0.0"
-                          }
-                        },
-                        {
-                          "node": {
-                            "name": "2.1.0"
-                          }
-                        },
-                        {
-                          "node": {
-                            "name": "2.2.0"
-                          }
-                        },
-                        {
-                          "node": {
-                            "name": "2.3.0"
-                          }
-                        }
-                      ]
-                    },
                     "packageManifest": {
                       "abbreviatedOid": "3571935"
                     }
@@ -74,15 +45,6 @@ class GitHubTests: XCTestCase {
                     },
                     "stargazers": {
                       "totalCount": 0
-                    },
-                    "tags": {
-                      "edges": [
-                        {
-                          "node": {
-                            "name": "0.1.0"
-                          }
-                        }
-                      ]
                     },
                     "packageManifest": {
                       "abbreviatedOid": "5338ca5"
@@ -105,25 +67,6 @@ class GitHubTests: XCTestCase {
                     "stargazers": {
                       "totalCount": 0
                     },
-                    "tags": {
-                      "edges": [
-                        {
-                          "node": {
-                            "name": "0.1.0"
-                          }
-                        },
-                        {
-                          "node": {
-                            "name": "0.2.0"
-                          }
-                        },
-                        {
-                          "node": {
-                            "name": "0.2.1"
-                          }
-                        }
-                      ]
-                    },
                     "packageManifest": {
                       "abbreviatedOid": "dcc137a"
                     }
@@ -145,9 +88,6 @@ class GitHubTests: XCTestCase {
                     "stargazers": {
                       "totalCount": 3
                     },
-                    "tags": {
-                      "edges": []
-                    },
                     "packageManifest": null
                   }
                 },
@@ -167,9 +107,6 @@ class GitHubTests: XCTestCase {
                     "stargazers": {
                       "totalCount": 1
                     },
-                    "tags": {
-                      "edges": []
-                    },
                     "packageManifest": null
                   }
                 },
@@ -188,9 +125,6 @@ class GitHubTests: XCTestCase {
                     },
                     "stargazers": {
                       "totalCount": 1
-                    },
-                    "tags": {
-                      "edges": []
                     },
                     "packageManifest": null
                   }
@@ -214,7 +148,6 @@ class GitHubTests: XCTestCase {
 
         XCTAssertEqual(response.data?.repositories.count, 3)
         XCTAssertEqual(response.data?.repositories[0].nameWithOwner, "kiliankoe/DVB")
-        XCTAssertEqual(response.data?.repositories[0].tags.first?.name, "1.1.0")
         XCTAssertTrue(response.data?.repositories[0].hasPackageManifest ?? false)
     }
 

--- a/Tests/ApodidaeTests/ManifestTests.swift
+++ b/Tests/ApodidaeTests/ManifestTests.swift
@@ -175,13 +175,8 @@ extension Repository {
         self.license = nil
         self.openIssues = 0
         self.stargazers = 0
-        self.tags = [Repository.Tag(name: "0.1.0")]
+        self.tags = ["0.1.0"]
+        self.heads = ["master"]
         self.hasPackageManifest = true
-    }
-}
-
-extension Repository.Tag {
-    init(name: String) {
-        self.name = name
     }
 }

--- a/Tests/ApodidaeTests/RepositoryTests.swift
+++ b/Tests/ApodidaeTests/RepositoryTests.swift
@@ -9,8 +9,11 @@ class RepositoryTests: XCTestCase {
     }
 
     func testLatestVersion() {
-        let repo = Repository(name: "kiliankoe/apodidae", url: "https://github.com/kiliankoe/apodidae")
+        var repo = Repository(name: "kiliankoe/apodidae", url: "https://github.com/kiliankoe/apodidae")
         XCTAssertEqual(repo.latestVersion, "0.1.0")
+
+        repo.tags = [Repository.Tag(with: "v0.2.0")]
+        XCTAssertEqual(repo.latestVersion, "0.2.0")
     }
 
     func testDependencyRepresentation() {

--- a/Tests/ApodidaeTests/RepositoryTests.swift
+++ b/Tests/ApodidaeTests/RepositoryTests.swift
@@ -42,4 +42,9 @@ class RepositoryTests: XCTestCase {
             XCTAssert(error is Repository.DependencyRepresentationError)
         }
     }
+
+    func testTagInit() {
+        XCTAssertEqual(Repository.Tag(with: "0.1.0").name, "0.1.0")
+        XCTAssertEqual(Repository.Tag(with: "v0.1.0").name, "0.1.0")
+    }
 }

--- a/Tests/ApodidaeTests/RepositoryTests.swift
+++ b/Tests/ApodidaeTests/RepositoryTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import ApodidaeCore
+
+class RepositoryTests: XCTestCase {
+    func testNameAndOwner() {
+        let repo = Repository(name: "kiliankoe/apodidae", url: "https://github.com/kiliankoe/apodidae")
+        XCTAssertEqual(repo.name, "apodidae")
+        XCTAssertEqual(repo.owner, "kiliankoe")
+    }
+
+    func testLatestVersion() {
+        let repo = Repository(name: "kiliankoe/apodidae", url: "https://github.com/kiliankoe/apodidae")
+        XCTAssertEqual(repo.latestVersion, "0.1.0")
+    }
+
+    func testDependencyRepresentation() {
+        let repo = Repository(name: "kiliankoe/apodidae", url: "https://github.com/kiliankoe/apodidae")
+
+        let swift4Latest = try! repo.dependencyRepresentation(for: .v4, requirement: .tag("0.1.0"))
+        XCTAssertEqual(swift4Latest, ".package(url: \"https://github.com/kiliankoe/apodidae\", from: \"0.1.0\"),")
+
+        let swift4Master = try! repo.dependencyRepresentation(for: .v4, requirement: .branch("master"))
+        XCTAssertEqual(swift4Master, ".package(url: \"https://github.com/kiliankoe/apodidae\", .branch(\"master\")),")
+
+        let swift4Revision = try! repo.dependencyRepresentation(for: .v4, requirement: .revision("foobar"))
+        XCTAssertEqual(swift4Revision, ".package(url: \"https://github.com/kiliankoe/apodidae\", .revision(\"foobar\")),")
+
+        let swift3Representable = try! repo.dependencyRepresentation(for: .v3, requirement: .tag("0.1.0"))
+        XCTAssertEqual(swift3Representable, ".Package(url: \"https://github.com/kiliankoe/apodidae\", majorVersion: 0, minor: 1),")
+
+        do {
+            let _ = try repo.dependencyRepresentation(for: .v3, requirement: .branch("master"))
+            XCTFail("Branch requirement should not be representable in Swift 3.")
+        } catch {
+            XCTAssert(error is Repository.DependencyRepresentationError)
+        }
+
+        do {
+            let _ = try repo.dependencyRepresentation(for: .v3, requirement: .revision("foobar"))
+            XCTFail("Revision requirement should not be representable in Swift 3.")
+        } catch {
+            XCTAssert(error is Repository.DependencyRepresentationError)
+        }
+    }
+}

--- a/Tests/ApodidaeTests/RepositoryTests.swift
+++ b/Tests/ApodidaeTests/RepositoryTests.swift
@@ -12,7 +12,7 @@ class RepositoryTests: XCTestCase {
         var repo = Repository(name: "kiliankoe/apodidae", url: "https://github.com/kiliankoe/apodidae")
         XCTAssertEqual(repo.latestVersion, "0.1.0")
 
-        repo.tags = ["0.2.0", "1.0.0"]
+        repo.tags = ["1.0.0", "0.2.0"]
         XCTAssertEqual(repo.latestVersion, "1.0.0")
     }
 

--- a/Tests/ApodidaeTests/RepositoryTests.swift
+++ b/Tests/ApodidaeTests/RepositoryTests.swift
@@ -12,8 +12,8 @@ class RepositoryTests: XCTestCase {
         var repo = Repository(name: "kiliankoe/apodidae", url: "https://github.com/kiliankoe/apodidae")
         XCTAssertEqual(repo.latestVersion, "0.1.0")
 
-        repo.tags = [Repository.Tag(with: "v0.2.0")]
-        XCTAssertEqual(repo.latestVersion, "0.2.0")
+        repo.tags = ["0.2.0", "1.0.0"]
+        XCTAssertEqual(repo.latestVersion, "1.0.0")
     }
 
     func testDependencyRepresentation() {
@@ -44,10 +44,5 @@ class RepositoryTests: XCTestCase {
         } catch {
             XCTAssert(error is Repository.DependencyRepresentationError)
         }
-    }
-
-    func testTagInit() {
-        XCTAssertEqual(Repository.Tag(with: "0.1.0").name, "0.1.0")
-        XCTAssertEqual(Repository.Tag(with: "v0.1.0").name, "0.1.0")
     }
 }


### PR DESCRIPTION
Resolves #18, resolves #25 

- [x] Handle tags with `v` prefix
- [x] Don't pull available tags from GitHub, but from `git ls-remote`
- [x] Check if actual version parsing is actually necessary
- [x] check for availability of specified requirements (obviously not for revisions) when specified
- [x] handle versions without patch level, e.g. `0.7` (in rxswift for example)