### PR TITLE
Fixed tests, moved dependency ShellOut to correct target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,10 +22,10 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "ApodidaeCore",
-            dependencies: ["PromiseKit", "Files", "Rainbow", "Regex", "CLISpinner"]),
+            dependencies: ["PromiseKit", "Files", "Rainbow", "Regex", "CLISpinner", "ShellOut"]),
         .target(
             name: "swift-catalog",
-            dependencies: ["ApodidaeCore", "CommandLine", "ShellOut", "CLISpinner", "Signals"]),
+            dependencies: ["ApodidaeCore", "CommandLine", "CLISpinner", "Signals"]),
         .testTarget(
             name: "ApodidaeTests",
             dependencies: ["ApodidaeCore"]),

--- a/Tests/ApodidaeTests/CommandTests.swift
+++ b/Tests/ApodidaeTests/CommandTests.swift
@@ -72,10 +72,13 @@ class CommandTests: XCTestCase {
         XCTAssertNotEqual(Command.info("foo"), Command.add(package: "foo", requirement: .tag("1.0.0")))
     }
 
-    static var allTests = [
-        ("testInit", testInit),
-        ("testSimpleQueries", testSimpleQueries),
-        ("testAdd", testAdd),
-        ("testEquality", testEquality),
-    ]
+    static var allTests: [(String, (CommandTests) -> () throws -> Void)] {
+        return [
+            ("testInit", testInit),
+            ("testSimpleQueries", testSimpleQueries),
+            ("testAdd", testAdd),
+            ("testEquality", testEquality),
+        ]
+    }
+    
 }

--- a/Tests/ApodidaeTests/ConfigTests.swift
+++ b/Tests/ApodidaeTests/ConfigTests.swift
@@ -18,7 +18,10 @@ class ConfigTests: XCTestCase {
         XCTAssertEqual(encoded, json)
     }
 
-    static var allTests = [
-        ("testSerialization", testSerialization),
-    ]
+    static var allTests: [(String, (ConfigTests) -> () throws -> Void)] {
+        return [
+            ("testSerialization", testSerialization),
+        ]
+    }
+    
 }

--- a/Tests/ApodidaeTests/GitHubTests.swift
+++ b/Tests/ApodidaeTests/GitHubTests.swift
@@ -186,8 +186,10 @@ class GitHubTests: XCTestCase {
 //        waitForExpectations(timeout: 5)
 //    }
 
-    static var allTests = [
-        ("testDeserialization", testDeserialization),
+    static var allTests: [(String, (GitHubTests) -> () throws -> Void)] {
+        return [
+            ("testDeserialization", testDeserialization),
 //        ("testGitHubRequest", testGitHubRequest),
-    ]
+        ]
+    }
 }

--- a/Tests/ApodidaeTests/ManifestTests.swift
+++ b/Tests/ApodidaeTests/ManifestTests.swift
@@ -160,6 +160,17 @@ class ManifestTests: XCTestCase {
         """
         XCTAssertEqual(newManifest, expected)
     }
+    
+    static var allTests: [(String, (ManifestTests) -> () throws -> Void)] {
+        return [
+            ("testLineNumberOfMatches", testLineNumberOfMatches),
+            ("testFindDependenciesInsert", testFindDependenciesInsert),
+            ("testFailingDependenciesInsert", testFailingDependenciesInsert),
+            ("testInsertPackageIntoManifestWithoutPackages", testInsertPackageIntoManifestWithoutPackages),
+            ("testInsertPackageIntoManifestWitSingleLineDependencies", testInsertPackageIntoManifestWitSingleLineDependencies),
+            ("testInsertPackageIntoManifestWithPackages", testInsertPackageIntoManifestWithPackages),
+        ]
+    }
 }
 
 extension Repository {

--- a/Tests/ApodidaeTests/RepositoryTests.swift
+++ b/Tests/ApodidaeTests/RepositoryTests.swift
@@ -45,4 +45,12 @@ class RepositoryTests: XCTestCase {
             XCTAssert(error is Repository.DependencyRepresentationError)
         }
     }
+    
+    static var allTests: [(String, (RepositoryTests) -> () throws -> Void)] {
+        return [
+            ("testNameAndOwner", testNameAndOwner),
+            ("testLatestVersion", testLatestVersion),
+            ("testDependencyRepresentation", testDependencyRepresentation),
+        ]
+    }
 }

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,5 +2,9 @@ import XCTest
 @testable import ApodidaeTests
 
 XCTMain([
-    testCase(ApodidaeTests.allTests),
+    testCase(CommandTests.allTests),
+    testCase(ConfigTests.allTests),
+    testCase(GitHubTests.allTests),
+    testCase(ManifestTests.allTests),
+    testCase(RepositoryTests.allTests),
 ])


### PR DESCRIPTION
The target ShellOut was used in ApodidaeCore but was not added as a dependency there, that resulted in a linker error when executing `swift test`. I don't know why Xcode didn't have a problem with that ¯\_(ツ)_/¯

I also fixed and completed the list of unit tests for testing on linux.